### PR TITLE
Fix core reference in new event workflow

### DIFF
--- a/.github/workflows/new_event.yml
+++ b/.github/workflows/new_event.yml
@@ -1,0 +1,138 @@
+name: Generate event from issue
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  create-event-file:
+    if: contains(github.event.issue.labels.*.name, 'new event')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create event file from issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { issue } = context.payload;
+            const { owner, repo } = context.repo;
+
+            const normalizeLineEndings = (text) => (text || '').replace(/\r\n/g, '\n');
+
+            const body = normalizeLineEndings(issue.body || '').trim();
+            if (!body) {
+              core.setFailed('Issue body is empty.');
+              return;
+            }
+
+            const mapping = {
+              'Дата': 'date',
+              'Город': 'city',
+              'Адрес проведения': 'address',
+              'Логотип': 'icon',
+              'Ссылка на регистрацию': 'registration_url',
+              'Краткое описание события': 'description',
+            };
+
+            const parsed = {};
+            const regex = /###\s+([^\n]+)\n+([\s\S]*?)(?=\n###\s+|$)/g;
+            let match;
+            while ((match = regex.exec(body)) !== null) {
+              const label = match[1].trim();
+              const key = mapping[label];
+              if (!key) {
+                continue;
+              }
+              const value = match[2].trim();
+              parsed[key] = value;
+            }
+
+            const requiredFields = ['date', 'city', 'description', 'registration_url'];
+            for (const field of requiredFields) {
+              if (!parsed[field] || !parsed[field].trim()) {
+                core.setFailed(`Поле "${field}" отсутствует или пустое в обращении.`);
+                return;
+              }
+            }
+
+            parsed.address = parsed.address ? parsed.address.trim() : '';
+            parsed.icon = parsed.icon ? parsed.icon.trim() : 'default.jpg';
+
+            const rawTitle = issue.title.replace(/^\[NEW EVENT\]\s*:?\s*/i, '').trim();
+            parsed.title = rawTitle || issue.title.trim();
+            parsed.date = parsed.date.trim();
+            parsed.city = parsed.city.trim();
+            parsed.description = parsed.description.trim();
+            parsed.registration_url = parsed.registration_url.trim();
+
+            const slugBase = (parsed.title || 'event')
+              .normalize('NFKD')
+              .replace(/[\u0300-\u036f]/g, '')
+              .replace(/[^A-Za-z0-9]+/g, '_')
+              .replace(/^_+|_+$/g, '')
+              .toUpperCase();
+
+            const baseName = `${parsed.date}_${slugBase || 'EVENT'}`;
+            let filePath = `events/${baseName}.yml`;
+            let counter = 1;
+
+            while (true) {
+              try {
+                await github.rest.repos.getContent({ owner, repo, path: filePath });
+                counter += 1;
+                filePath = `events/${baseName}_${counter}.yml`;
+              } catch (error) {
+                if (error.status === 404) {
+                  break;
+                }
+                throw error;
+              }
+            }
+
+            const formatValue = (value) => {
+              if (value === undefined || value === null || value === '') {
+                return '""';
+              }
+              if (typeof value !== 'string') {
+                value = String(value);
+              }
+              if (value.includes('\n')) {
+                const lines = value.split('\n').map((line) => line.trimEnd());
+                const indented = lines.map((line) => `  ${line}`).join('\n');
+                return `|\n${indented}`;
+              }
+              const escaped = value.replace(/"/g, '\\"');
+              return `"${escaped}"`;
+            };
+
+            const yamlLines = [
+              `title: ${formatValue(parsed.title)}`,
+              `date: ${formatValue(parsed.date)}`,
+              `city: ${formatValue(parsed.city)}`,
+              `address: ${formatValue(parsed.address)}`,
+              `icon: ${formatValue(parsed.icon)}`,
+              `description: ${formatValue(parsed.description)}`,
+              `registration_url: ${formatValue(parsed.registration_url)}`,
+            ];
+            const content = `${yamlLines.join('\n')}\n`;
+
+            await github.rest.repos.createOrUpdateFileContents({
+              owner,
+              repo,
+              path: filePath,
+              message: `feat: add event from issue #${issue.number}`,
+              content: Buffer.from(content, 'utf8').toString('base64'),
+            });
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issue.number,
+              body: `Файл события создан: \`${filePath}\``,
+            });
+


### PR DESCRIPTION
## Summary
- add a workflow that reacts to newly opened issues labeled "new event"
- parse issue form inputs and build a YAML event file in the events directory
- post a confirmation comment with the created file path
- use the provided github-script core instance to avoid redeclaration errors

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c9acda986c8322809538a4e62cb77b